### PR TITLE
Mark private member public [FirebaseItemAdapter]

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/firebaseclient/src/main/java/com/californiadreamshostel/firebaseclient/FirebaseItemAdapter.kt
+++ b/firebaseclient/src/main/java/com/californiadreamshostel/firebaseclient/FirebaseItemAdapter.kt
@@ -2,7 +2,7 @@ package com.californiadreamshostel.firebaseclient
 
 import com.google.firebase.database.DataSnapshot
 
-class ReferenceItemAdapter(private val group: String?, private var itemFactory: ((String, String, String) -> ReferenceItem)? = null) {
+class ReferenceItemAdapter(private val group: String?, var itemFactory: ((String, String, String) -> ReferenceItem)? = null) {
 
     companion object {
         const val ROOT = "Root"


### PR DESCRIPTION
Marked member "FirebaseItemAdapter.ItemFactory" as private, then tried to access it. Fixed that issue preventing a successful release.